### PR TITLE
Removed broken reference to dependency_links in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     license                 = 'http://opensource.org/licenses/MIT',
     long_description        = README,
     install_requires        = install_requires,
-    dependency_links        = dependency_links,
     packages                = find_packages(exclude = ['contrib', 'docs', 'tests']),
     include_package_data    = True
 )


### PR DESCRIPTION
There is a broken reference to a `dependency_links` variable in `setup.py` that will prevent `pip install -e .` from running.